### PR TITLE
Always run with --in-place

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,7 +1,5 @@
 -   id: autoflake
     name: autoflake
-    entry: autoflake
+    entry: autoflake --in-place
     language: python
     files: \.py$
-    args: ['-i']
-


### PR DESCRIPTION
This is the same issue as https://github.com/doublify/pre-commit-clang-format/pull/5

When someone using this hook wants to overwrite `args:` the `--in-place`/`-i` flag gets removed. This way it doesn't.