### PR TITLE
Update to latest autoflakes version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,5 +4,5 @@ from setuptools import setup
 setup(
     name='pre_commit_dummy_package',
     version='0.0.0',
-    install_requires=['autoflake==1.3'],
+    install_requires=['autoflake==1.3.1'],
 )


### PR DESCRIPTION
Version 1.3.1 adds the ability to ignore `__init__.py` files. 

```
--ignore-init-module-imports
                        exclude __init__.py when removing unused imports
```

Given the release date of Aug 4, 2019 it's probably fair to assume this is fairly stable